### PR TITLE
Add Arqus A5 and A12 to camera model enum

### DIFF
--- a/QTMSettings.cs
+++ b/QTMSettings.cs
@@ -832,6 +832,10 @@ namespace QTMRealTimeSDK.Settings
         ModelMiqusVideoColor,
         [XmlEnum("Miqus Hybrid")]
         ModelMiqusHybrid,
+        [XmlEnum("Arqus A5")]
+        ModelArqusA5,
+        [XmlEnum("Arqus A12")]
+        ModelArqusA12,
     }
 
     /// <summary>Camera modes</summary>


### PR DESCRIPTION
Add support for camera types Arqus A5 and Arqus A12