### PR TITLE
Add support for new skeleton xml and 6dof xml

### DIFF
--- a/QTMSettings.cs
+++ b/QTMSettings.cs
@@ -340,7 +340,7 @@ namespace QTMRealTimeSDK.Settings
     }
 
     /// <summary>Skeleton segment</summary>
-    public class SettingSkeletonSegmentRecursive
+    public class SettingSkeletonSegmentHierarchical
     {
         [XmlAttribute("Name")]
         public string Name;
@@ -359,19 +359,19 @@ namespace QTMRealTimeSDK.Settings
         [XmlElement("RigidBodies")]
         public RigidBodies RigidBodies;
         [XmlElement("Segment")]
-        public List<SettingSkeletonSegmentRecursive> Segments;
+        public List<SettingSkeletonSegmentHierarchical> Segments;
     }
 
     /// <summary>Skeleton segments</summary>
-    public class SegmentsRecursive
+    public class SegmentsHierarchical
     {
         [XmlElement("Segment")]
-        public List<SettingSkeletonSegmentRecursive> Segments;
+        public List<SettingSkeletonSegmentHierarchical> Segments;
     }
 
 
     /// <summary>Skeleton</summary>
-    public class SettingSkeletonRecursive
+    public class SettingSkeletonHierarchical
     {
         [XmlAttribute("Name")]
         public string Name;
@@ -380,18 +380,18 @@ namespace QTMRealTimeSDK.Settings
         [XmlElement("Scale")]
         public string Scale;
         [XmlElement("Segments")]
-        public SegmentsRecursive Segments;
+        public SegmentsHierarchical Segments;
     }
 
     /// <summary>
     /// Skeleton Settings from QTM.
-    /// The skeleton is stored recursively.
+    /// The skeleton is stored hierarchicaly.
     /// </summary>
     [XmlRoot("Skeletons")]
-    public class SettingsSkeletonsRecursive : SettingsBase
+    public class SettingsSkeletonsHierarchical : SettingsBase
     {
         [XmlElement("Skeleton")]
-        public List<SettingSkeletonRecursive> Skeletons;
+        public List<SettingSkeletonHierarchical> Skeletons;
     }
 
     /// <summary>Skeleton segment</summary>

--- a/QTMSettings.cs
+++ b/QTMSettings.cs
@@ -294,8 +294,8 @@ namespace QTMRealTimeSDK.Settings
         public Rotation Rotation;
     }
 
-    /// <summary>Boundry</summary>
-    public class Boundry
+    /// <summary>Boundary</summary>
+    public class Boundary
     {
         [XmlAttribute("LowerBound")]
         public float LowerBound;
@@ -307,17 +307,17 @@ namespace QTMRealTimeSDK.Settings
     public class DegreesOfFreedom
     {
         [XmlElement("RotationX")]
-        public Boundry RotationX;
+        public Boundary RotationX;
         [XmlElement("RotationY")]
-        public Boundry RotationY;
+        public Boundary RotationY;
         [XmlElement("RotationZ")]
-        public Boundry RotationZ;
+        public Boundary RotationZ;
         [XmlElement("TranslationX")]
-        public Boundry TranslationX;
+        public Boundary TranslationX;
         [XmlElement("TranslationY")]
-        public Boundry TranslationY;
+        public Boundary TranslationY;
         [XmlElement("TranslationZ")]
-        public Boundry TranslationZ;
+        public Boundary TranslationZ;
     }
 
     /// <summary>Marker</summary>

--- a/QTMSettings.cs
+++ b/QTMSettings.cs
@@ -217,7 +217,142 @@ namespace QTMRealTimeSDK.Settings
         public float W;
     }
 
-    /// <summary>Segment</summary>
+    /// <summary>Transform</summary>
+    public class Transform
+    {
+        [XmlElement("Position")]
+        public Position Position;
+        [XmlElement("Rotation")]
+        public Rotation Rotation;
+    }
+
+    /// <summary>DefaultTransform</summary>
+    public class DefaultTransform
+    {
+        [XmlElement("Position")]
+        public Position Position;
+        [XmlElement("Rotation")]
+        public Rotation Rotation;
+    }
+
+    /// <summary>Boundry</summary>
+    public class Boundry
+    {
+        [XmlAttribute("LowerBound")]
+        public float LowerBound;
+        [XmlAttribute("UpperBound")]
+        public float UpperBound;
+    }
+
+    /// <summary>DegreesOfFreedom</summary>
+    public class DegreesOfFreedom
+    {
+        [XmlElement("RotationX")]
+        public Boundry RotationX;
+        [XmlElement("RotationY")]
+        public Boundry RotationY;
+        [XmlElement("RotationZ")]
+        public Boundry RotationZ;
+        [XmlElement("TranslationX")]
+        public Boundry TranslationX;
+        [XmlElement("TranslationY")]
+        public Boundry TranslationY;
+        [XmlElement("TranslationZ")]
+        public Boundry TranslationZ;
+    }
+
+    /// <summary>Marker</summary>
+    public class Marker
+    {
+        [XmlAttribute("Name")]
+        public string Name;
+        [XmlElement("Position")]
+        public Position Position;
+        [XmlElement("Weight")]
+        public float Weight;
+    }
+
+    /// <summary>Markers</summary>
+    public class Markers
+    {
+        [XmlElement("Marker")]
+        public List<Marker> MarkerList;
+    }
+
+    /// <summary>RigidBody</summary>
+    public class RigidBody
+    {
+        [XmlAttribute("Name")]
+        public string Name;
+        [XmlElement("Transform")]
+        public Transform Transform;
+        [XmlElement("Weight")]
+        public float Weight;
+    }
+
+    /// <summary>RigidBodies</summary>
+    public class RigidBodies
+    {
+        [XmlElement("RigidBody")]
+        public List<RigidBody> RigidBodyList;
+    }
+
+    /// <summary>Skeleton segment</summary>
+    public class SettingSkeletonSegmentRecursive
+    {
+        [XmlAttribute("Name")]
+        public string Name;
+        [XmlAttribute("ID")]
+        public uint Id;
+        [XmlElement("Transform")]
+        public Transform Transform;
+        [XmlElement("DefaultTransform")]
+        public DefaultTransform DefaultTransform;
+        [XmlElement("DegreesOfFreedom")]
+        public DegreesOfFreedom DegreesOfFreedom;
+        [XmlElement("Endpoint")]
+        public Position Endpoint;
+        [XmlElement("Markers")]
+        public Markers Markers;
+        [XmlElement("RigidBodies")]
+        public RigidBodies RigidBodies;
+        [XmlElement("Segment")]
+        public List<SettingSkeletonSegmentRecursive> Segments;
+    }
+
+    /// <summary>Skeleton segments</summary>
+    public class SegmentsRecursive
+    {
+        [XmlElement("Segment")]
+        public List<SettingSkeletonSegmentRecursive> Segments;
+    }
+
+
+    /// <summary>Skeleton</summary>
+    public class SettingSkeletonRecursive
+    {
+        [XmlAttribute("Name")]
+        public string Name;
+        [XmlElement("Solver")]
+        public string Solver;
+        [XmlElement("Scale")]
+        public string Scale;
+        [XmlElement("Segments")]
+        public SegmentsRecursive Segments;
+    }
+
+    /// <summary>
+    /// Skeleton Settings from QTM.
+    /// The skeleton is stored recursively.
+    /// </summary>
+    [XmlRoot("Skeletons")]
+    public class SettingsSkeletonsRecursive : SettingsBase
+    {
+        [XmlElement("Skeleton")]
+        public List<SettingSkeletonRecursive> Skeletons;
+    }
+
+    /// <summary>Skeleton segment</summary>
     public class SettingSkeletonSegment
     {
         [XmlAttribute("Name")]
@@ -241,7 +376,10 @@ namespace QTMRealTimeSDK.Settings
         public List<SettingSkeletonSegment> Segments;
     }
 
-    /// <summary>Skeleton Settings from QTM</summary>
+    /// <summary>
+    /// Skeleton Settings from QTM.
+    /// The skeleton is stored in a vector.
+    /// </summary>
     [XmlRoot("Skeletons")]
     public class SettingsSkeletons : SettingsBase
     {
@@ -303,22 +441,25 @@ namespace QTMRealTimeSDK.Settings
         /// <summary>Video Field Of View, left, top, right and bottom coordinates</summary>
         [XmlElement("Video_FOV")]
         public FieldOfView VideoFOV;
-        /// <summary>Sync out settings for Oqus sync out or Miqus Sync Unit Out1</summary>
+        /// <summary>Sync out settings for Oqus sync out or Sync Unit Out1</summary>
         [XmlElement("Sync_Out")]
         public SettingsSyncOut SyncOut;
-        /// <summary>Sync out settings for Miqus Sync Unit Out2</summary>
+        /// <summary>Sync out settings for Sync Unit Out2</summary>
         [XmlElement("Sync_Out2")]
         public SettingsSyncOut SyncOut2;
-        /// <summary>Sync out settings for Miqus Sync Unit Measurement Time (MT)</summary>
+        /// <summary>Sync out settings for Sync Unit Measurement Time (MT)</summary>
         [XmlElement("Sync_Out_MT")]
         public SettingsSyncOut SyncOutMT;
         /// <summary>Lens Control settings for camera equipped with motorized lens</summary>
         [XmlElement("LensControl")]
         public SettingsLensControl LensControl;
+        /// <summary>Auto exposure settings for video camera</summary>
         [XmlElement("AutoExposure")]
         public SettingsAutoExposure AutoExposure;
+        /// <summary>Video resolution for non-marker cameras</summary>
         [XmlElement("Video_Resolution")]
         public SettingsVideoResolution VideoResolution;
+        /// <summary>Video aspect ratio for non-marker cameras</summary>
         [XmlElement("Video_Aspect_Ratio")]
         public SettingsVideoAspectRatio VideoAspectRatio;
     }
@@ -326,8 +467,10 @@ namespace QTMRealTimeSDK.Settings
     /// <summary>Settings regarding Lens Control for camera equipped with motorized lens</summary>
     public struct SettingsLensControl
     {
+        /// <summary>Camera focus lens control</summary>
         [XmlElement("Focus")]
         public SettingsLensControlValues Focus;
+        /// <summary>Camera aperture lens control</summary>
         [XmlElement("Aperture")]
         public SettingsLensControlValues Aperture;
     }

--- a/RTProtocol.cs
+++ b/RTProtocol.cs
@@ -956,6 +956,7 @@ namespace QTMRealTimeSDK
                 if (GetSettings("Skeleton", "Skeletons", out mSkeletonSettingsRecursive))
                 {
                     mSkeletonSettings = new SettingsSkeletons();
+                    mSkeletonSettings.Xml = mSkeletonSettingsRecursive.Xml;
                     mSkeletonSettings.Skeletons = new List<SettingSkeleton>();
 
                     foreach (var skeleton in mSkeletonSettingsRecursive.Skeletons)

--- a/RTProtocol.cs
+++ b/RTProtocol.cs
@@ -1004,8 +1004,8 @@ namespace QTMRealTimeSDK
                     return true;
                 }
             }
-            mSkeletonSettings = default;
-            mSkeletonSettingsHierarchical = default;
+            mSkeletonSettings = default(SettingsSkeletons);
+            mSkeletonSettingsHierarchical = default(SettingsSkeletonsHierarchical);
             return false;
         }
 
@@ -1030,38 +1030,38 @@ namespace QTMRealTimeSDK
             return false;
         }
 
-        public bool SetGeneralSettings(in SettingsGeneral settings)
+        public bool SetGeneralSettings(SettingsGeneral settings)
         {
-            return SetSettings("General", "General", in settings);
+            return SetSettings("General", "General", settings);
         }
 
-        public bool Set6DSettings(in Settings6D settings)
+        public bool Set6DSettings(Settings6D settings)
         {
             if (mMajorVersion > 1 || mMinorVersion > 20)
             {
                 Settings6D_V2 settings6D_v2 = new Settings6D_V2(settings);
-                return SetSettings("6D", "The_6D", in settings6D_v2);
+                return SetSettings("6D", "The_6D", settings6D_v2);
             }
             mErrorString = "Can not set 6D settings in protocol versions prior to 1.21";
             return false;
         }
 
-        public bool SetForceSettings(in SettingsForce settings)
+        public bool SetForceSettings(SettingsForce settings)
         {
-            return SetSettings("Force", "Force", in settings);
+            return SetSettings("Force", "Force", settings);
         }
 
-        public bool SetImageSettings(in SettingsImage settings)
+        public bool SetImageSettings(SettingsImage settings)
         {
-            return SetSettings("Image", "Image", in settings);
+            return SetSettings("Image", "Image", settings);
         }
 
-        public bool SetSkeletonSettings(in SettingsSkeletonsHierarchical settings)
+        public bool SetSkeletonSettings(SettingsSkeletonsHierarchical settings)
         {
-            return SetSettings("Skeleton", "Skeletons", in settings);
+            return SetSettings("Skeleton", "Skeletons", settings);
         }
 
-        public bool SetSettings<TSettings>(string settingsName, string settingXmlName, in TSettings settingObject)
+        public bool SetSettings<TSettings>(string settingsName, string settingXmlName, TSettings settingObject)
         {
             var xmlSettings = RTProtocol.CreateSettingsXml(settingObject, out mErrorString);
             if (xmlSettings != string.Empty)

--- a/RTProtocol.cs
+++ b/RTProtocol.cs
@@ -167,9 +167,9 @@ namespace QTMRealTimeSDK
         /// <summary>Skeleton settings from QTM</summary>
         public SettingsSkeletons SkeletonSettings { get { return mSkeletonSettings; } }
 
-        private SettingsSkeletonsRecursive mSkeletonSettingsRecursive;
+        private SettingsSkeletonsHierarchical mSkeletonSettingsHierarchical;
         /// <summary>Skeleton settings from QTM</summary>
-        public SettingsSkeletonsRecursive SkeletonSettingsRecursive { get { return mSkeletonSettingsRecursive; } }
+        public SettingsSkeletonsHierarchical SkeletonSettingsHierarchical { get { return mSkeletonSettingsHierarchical; } }
 
         private bool mBroadcastSocketCreated = false;
         private RTNetwork mNetwork;
@@ -953,15 +953,15 @@ namespace QTMRealTimeSDK
             }
             else
             {
-                if (GetSettings("Skeleton", "Skeletons", out mSkeletonSettingsRecursive))
+                if (GetSettings("Skeleton", "Skeletons", out mSkeletonSettingsHierarchical))
                 {
                     mSkeletonSettings = new SettingsSkeletons();
-                    mSkeletonSettings.Xml = mSkeletonSettingsRecursive.Xml;
+                    mSkeletonSettings.Xml = mSkeletonSettingsHierarchical.Xml;
                     mSkeletonSettings.Skeletons = new List<SettingSkeleton>();
 
-                    foreach (var skeleton in mSkeletonSettingsRecursive.Skeletons)
+                    foreach (var skeleton in mSkeletonSettingsHierarchical.Skeletons)
                     {
-                        Action<List<SettingSkeletonSegment>, SettingSkeletonSegmentRecursive, uint> RecurseSegments = null;
+                        Action<List<SettingSkeletonSegment>, SettingSkeletonSegmentHierarchical, uint> RecurseSegments = null;
                         RecurseSegments = (segmentList, segment, parentId) =>
                         {
                             SettingSkeletonSegment newSegment = new SettingSkeletonSegment
@@ -994,7 +994,7 @@ namespace QTMRealTimeSDK
                 }
             }
             mSkeletonSettings = default;
-            mSkeletonSettingsRecursive = default;
+            mSkeletonSettingsHierarchical = default;
             return false;
         }
 
@@ -1045,7 +1045,7 @@ namespace QTMRealTimeSDK
             return SetSettings("Image", "Image", in settings);
         }
 
-        public bool SetSkeletonSettings(in SettingsSkeletonsRecursive settings)
+        public bool SetSkeletonSettings(in SettingsSkeletonsHierarchical settings)
         {
             return SetSettings("Skeleton", "Skeletons", in settings);
         }


### PR DESCRIPTION
## Add support for the new skeleton xml and 6dof xml. 

**Changes in 6dof settings**
\- Euler Names (Moved to general settings as Euler Angles)
**Per body:**
\+ MaximumResidual
\+ MinimumMarkersInBody
\+ BoneLengthTolerance
\+ Filter
\+ Mesh
\+ DataOrigin
\+ DataOrientation
**Per body point:**
\+ Name

**Changes in skeletons settings**
New class, SettingSkeletonHierarchical. New skeleton settings:
\+ Solver
\+ Scale
New class, SettingSkeletonSegmentHierarchical. New segment settings:
\+ Default transform
\+ Degrees of freedom
\+ Endpoint
\+ Markers
\+ Rigid bodies