### PR TITLE
Assure whole packets are always read

### DIFF
--- a/RTProtocol.cs
+++ b/RTProtocol.cs
@@ -424,7 +424,7 @@ namespace QTMRealTimeSDK
                     {
                         // As long as we haven't received enough data, wait for more
                         received = mNetwork.Receive(ref data, receivedTotal, frameSize - receivedTotal, false, -1);
-                        if (received < 0)
+                        if (received <= 0)
                         {
                             if (!mNetwork.IsConnected())
                             {

--- a/RTProtocol.cs
+++ b/RTProtocol.cs
@@ -423,8 +423,8 @@ namespace QTMRealTimeSDK
                     while (receivedTotal < frameSize)
                     {
                         // As long as we haven't received enough data, wait for more
-                        received = mNetwork.Receive(ref data, receivedTotal, frameSize - receivedTotal, false, timeout);
-                        if (received <= 0)
+                        received = mNetwork.Receive(ref data, receivedTotal, frameSize - receivedTotal, false, -1);
+                        if (received < 0)
                         {
                             if (!mNetwork.IsConnected())
                             {


### PR DESCRIPTION
By setting the inner receive to blocking we assures that the whole packet is always read. This is needed since otherwise we could read partial packets which would invalidate the next receive. 