### PR TITLE
Receive function fixes

### DIFF
--- a/QtmCaptureTimer/MainWindow.xaml.cs
+++ b/QtmCaptureTimer/MainWindow.xaml.cs
@@ -145,7 +145,7 @@ namespace QtmCaptureTimer
 
                     // Get RTPacket from stream
                     PacketType packetType;
-                    if (rtProtocol.Receive(out packetType, false) == ReceiveResponseType.success)
+                    if (rtProtocol.Receive(out packetType, false) == QTMRealTimeSDK.Network.ResponseType.success)
                     {
 
                         // Handle data packet

--- a/QtmCaptureTimer/MainWindow.xaml.cs
+++ b/QtmCaptureTimer/MainWindow.xaml.cs
@@ -145,7 +145,7 @@ namespace QtmCaptureTimer
 
                     // Get RTPacket from stream
                     PacketType packetType;
-                    if (rtProtocol.ReceiveRTPacket(out packetType, false) > 0)
+                    if (rtProtocol.Receive(out packetType, false) == ReceiveResponseType.success)
                     {
 
                         // Handle data packet

--- a/RTClientSDK.Net.Example/Example2d.cs
+++ b/RTClientSDK.Net.Example/Example2d.cs
@@ -49,7 +49,7 @@ namespace RTClientSDK.Net.Example
 
             // Get RTPacket from stream
             PacketType packetType;
-            mRtProtocol.ReceiveRTPacket(out packetType, false);
+            mRtProtocol.Receive(out packetType, false);
 
             // Handle data packet
             if (packetType == PacketType.PacketData)

--- a/RTClientSDK.Net.Example/Example3d.cs
+++ b/RTClientSDK.Net.Example/Example3d.cs
@@ -49,7 +49,7 @@ namespace RTClientSDK.Net.Example
 
             // Get RTPacket from stream
             PacketType packetType;
-            mRtProtocol.ReceiveRTPacket(out packetType, false);
+            mRtProtocol.Receive(out packetType, false);
 
             // Handle data packet
             if (packetType == PacketType.PacketData)

--- a/RTClientSDK.Net.Example/Example6d.cs
+++ b/RTClientSDK.Net.Example/Example6d.cs
@@ -43,7 +43,7 @@ namespace RTClientSDK.Net.Example
 
             // Get RTPacket from stream
             PacketType packetType;
-            mRtProtocol.ReceiveRTPacket(out packetType, false);
+            mRtProtocol.Receive(out packetType, false);
 
             // Handle data packet
             if (packetType == PacketType.PacketData)

--- a/RTClientSDK.Net.Example/ExampleEyeTracker.cs
+++ b/RTClientSDK.Net.Example/ExampleEyeTracker.cs
@@ -43,7 +43,7 @@ namespace RTClientSDK.Net.Example
 
             // Get RTPacket from stream
             PacketType packetType;
-            mRtProtocol.ReceiveRTPacket(out packetType, false);
+            mRtProtocol.Receive(out packetType, false);
 
             // Handle data packet
             if (packetType == PacketType.PacketData)

--- a/RTClientSDK.Net.Example/ExampleGaze.cs
+++ b/RTClientSDK.Net.Example/ExampleGaze.cs
@@ -43,7 +43,7 @@ namespace RTClientSDK.Net.Example
 
             // Get RTPacket from stream
             PacketType packetType;
-            mRtProtocol.ReceiveRTPacket(out packetType, false);
+            mRtProtocol.Receive(out packetType, false);
 
             // Handle data packet
             if (packetType == PacketType.PacketData)

--- a/RTClientSDK.Net.Example/ExampleImage.cs
+++ b/RTClientSDK.Net.Example/ExampleImage.cs
@@ -93,7 +93,7 @@ namespace RTClientSDK.Net.Example
 
             // Get RTPacket from stream
             PacketType packetType;
-            mRtProtocol.ReceiveRTPacket(out packetType, false);
+            mRtProtocol.Receive(out packetType, false);
 
             // Handle data packet
             if (packetType == PacketType.PacketData)

--- a/RTClientSDK.Net.Example/ExampleSkeleton.cs
+++ b/RTClientSDK.Net.Example/ExampleSkeleton.cs
@@ -43,7 +43,7 @@ namespace RTClientSDK.Net.Example
 
             // Get RTPacket from stream
             PacketType packetType;
-            mRtProtocol.ReceiveRTPacket(out packetType, false);
+            mRtProtocol.Receive(out packetType, false);
 
             // Handle data packet
             if (packetType == PacketType.PacketData)

--- a/RTClientSDK.Net.Example/ExampleTimecode.cs
+++ b/RTClientSDK.Net.Example/ExampleTimecode.cs
@@ -44,7 +44,7 @@ namespace RTClientSDK.Net.Example
 
             // Get RTPacket from stream
             PacketType packetType;
-            mRtProtocol.ReceiveRTPacket(out packetType, false);
+            mRtProtocol.Receive(out packetType, false);
 
             // Handle data packet
             if (packetType == PacketType.PacketData)

--- a/RTClientSDK.Net.Example/ExampleUDP.cs
+++ b/RTClientSDK.Net.Example/ExampleUDP.cs
@@ -45,7 +45,7 @@ namespace RTClientSDK.Net.Example
 
             // Get RTPacket from stream
             PacketType packetType;
-            mRtProtocol.ReceiveRTPacket(out packetType, false);
+            mRtProtocol.Receive(out packetType, false);
 
             // Handle data packet
             if (packetType == PacketType.PacketData)

--- a/RTClientSDK.Net.SimpleExample/TakeControl.cs
+++ b/RTClientSDK.Net.SimpleExample/TakeControl.cs
@@ -87,7 +87,7 @@ namespace RTSDKExample
 
             // Get RTPacket from stream
             PacketType packetType;
-            rtProtocol.ReceiveRTPacket(out packetType, false);
+            rtProtocol.Receive(out packetType, false);
 
             // Handle 6DOF rigid body data
             if (packetType == PacketType.PacketData)

--- a/RTNetwork.cs
+++ b/RTNetwork.cs
@@ -8,15 +8,16 @@ using System;
 
 namespace QTMRealTimeSDK.Network
 {
-    internal class Response
+    public enum ResponseType
     {
-        internal enum ResponseType
-        {
-            success,
-            timeout,
-            disconnect,
-            error
-        }
+        success,
+        timeout,
+        disconnect,
+        error
+    }
+
+    internal struct Response
+    {
         internal int received;
         internal ResponseType type;
 
@@ -178,7 +179,7 @@ namespace QTMRealTimeSDK.Network
             if (mUDPBroadcastClient == null)
             {
                 mErrorString = "No clients to receive from.";
-                return new Response(Response.ResponseType.error, 0);
+                return new Response(ResponseType.error, 0);
             }
 
             try
@@ -198,17 +199,17 @@ namespace QTMRealTimeSDK.Network
                 {
                     // Error from broadcast socket
                     mErrorString = "Error reading from Broadcast UDP socket";
-                    return new Response(Response.ResponseType.error, 0);
+                    return new Response(ResponseType.error, 0);
                 }
                 else if (mUDPBroadcastClient != null && receiveList.Contains(mUDPBroadcastClient.Client))
                 {
                     // Receive data from broadcast socket
                     int received = mUDPBroadcastClient.Client.ReceiveFrom(receivebuffer, bufferSize, SocketFlags.None, ref remoteEP);
-                    return new Response((received == 0) ? Response.ResponseType.disconnect : Response.ResponseType.success, received);
+                    return new Response((received == 0) ? ResponseType.disconnect : ResponseType.success, received);
                 }
                 else
                 {
-                    return new Response(Response.ResponseType.timeout, 0);
+                    return new Response(ResponseType.timeout, 0);
                 }
             }
             catch (SocketException exception)
@@ -216,12 +217,12 @@ namespace QTMRealTimeSDK.Network
                 // Ignore and return
                 mErrorString = exception.Message;
             }
-            return new Response(Response.ResponseType.error, 0);
+            return new Response(ResponseType.error, 0);
         }
 
         internal Response Receive(ref byte[] receivebuffer, int offset, int bufferSize, bool header, int timeout)
         {
-            var response = new Response(Response.ResponseType.error, 0);
+            var response = new Response(ResponseType.error, 0);
             
             try
             {
@@ -244,7 +245,7 @@ namespace QTMRealTimeSDK.Network
                 {
                     receivebuffer = null;
                     mErrorString = "No clients to receive from.";
-                    return new Response(Response.ResponseType.error, 0);
+                    return new Response(ResponseType.error, 0);
                 }
 
                 Socket.Select(receiveList, null, errorList, timeout);
@@ -254,29 +255,29 @@ namespace QTMRealTimeSDK.Network
                 {
                     // Error from TCP socket
                     mErrorString = "Error reading from TCP socket";
-                    return new Response(Response.ResponseType.error, 0);
+                    return new Response(ResponseType.error, 0);
                 }
                 else if (mTCPClient != null && receiveList.Contains(mTCPClient.Client))
                 {
                     // Receive data from TCP socket
                     int received = mTCPClient.Client.Receive(receivebuffer, offset, header ? RTProtocol.Constants.PACKET_HEADER_SIZE : bufferSize, SocketFlags.None);
-                    return new Response((received == 0) ? Response.ResponseType.disconnect : Response.ResponseType.success, received);
+                    return new Response((received == 0) ? ResponseType.disconnect : ResponseType.success, received);
                 }
                 else if (mUDPClient != null && errorList.Contains(mUDPClient.Client))
                 {
                     // Error from UDP socket
                     mErrorString = "Error reading from UDP socket";
-                    return new Response(Response.ResponseType.error, 0);
+                    return new Response(ResponseType.error, 0);
                 }
                 else if (mUDPClient != null && receiveList.Contains(mUDPClient.Client))
                 {
                     // Receive data from UDP socket
                     int received = mUDPClient.Client.Receive(receivebuffer, offset, bufferSize, SocketFlags.None);
-                    return new Response((received == 0) ? Response.ResponseType.disconnect : Response.ResponseType.success, received);
+                    return new Response((received == 0) ? ResponseType.disconnect : ResponseType.success, received);
                 }
                 else
                 {
-                    return new Response(Response.ResponseType.timeout, 0);
+                    return new Response(ResponseType.timeout, 0);
                 }
             }
             catch (SocketException exception)
@@ -284,7 +285,7 @@ namespace QTMRealTimeSDK.Network
                 // Ignore and return
                 mErrorString = exception.Message;
             }
-            return new Response(Response.ResponseType.error, 0);
+            return new Response(ResponseType.error, 0);
         }
 
         /// <summary>

--- a/RTProtocol.cs
+++ b/RTProtocol.cs
@@ -452,10 +452,11 @@ namespace QTMRealTimeSDK
                     while (receivedTotal < frameSize)
                     {
                         // As long as we haven't received enough data, wait for more
-                        response = mNetwork.Receive(ref data, receivedTotal, frameSize - receivedTotal, false, -1);
+                        response = mNetwork.Receive(ref data, receivedTotal, frameSize - receivedTotal, false, 5000000);
                         if (response == Response.ResponseType.timeout)
                         {
-                            return ReceiveResponseType.timeout; // Receive timeout
+                            mErrorString = "Packet truncated.";
+                            return ReceiveResponseType.error;
                         }
                         if (response == Response.ResponseType.error)
                         {

--- a/RTProtocol.cs
+++ b/RTProtocol.cs
@@ -66,6 +66,8 @@ namespace QTMRealTimeSDK
             public const int STANDARD_BASE_PORT = 22222;
             /// <summary>Port QTM listens to for discovery requests</summary>
             public const int STANDARD_BROADCAST_PORT = 22226;
+            /// <summary>QTM packet data part read timeout in microseconds</summary>
+            public const int SOCKET_READ_TIMEOUT = 5000000; // 5 sec
 
         }
 
@@ -373,7 +375,7 @@ namespace QTMRealTimeSDK
         private Object receiveLock = new Object();
 
         [Obsolete("ReceiveRTPacket is deprecated and replaced by Receive.", false)]
-        public int ReceiveRTPacket(out PacketType packetType, bool skipEvents = true, int timeout = 5000000)
+        public int ReceiveRTPacket(out PacketType packetType, bool skipEvents = true, int timeout = Constants.SOCKET_READ_TIMEOUT)
         {
             int returnVal = -1;
             var response = Receive(out packetType, skipEvents, timeout);
@@ -395,7 +397,7 @@ namespace QTMRealTimeSDK
             return returnVal;
         }
 
-        public ResponseType Receive(out PacketType packetType, bool skipEvents = true, int timeout = 5000000)
+        public ResponseType Receive(out PacketType packetType, bool skipEvents = true, int timeout = Constants.SOCKET_READ_TIMEOUT)
         {
             lock (receiveLock)
             {
@@ -444,7 +446,7 @@ namespace QTMRealTimeSDK
                     while (receivedTotal < frameSize)
                     {
                         // As long as we haven't received enough data, wait for more
-                        response = mNetwork.Receive(ref data, receivedTotal, frameSize - receivedTotal, false, 5000000);
+                        response = mNetwork.Receive(ref data, receivedTotal, frameSize - receivedTotal, false, Constants.SOCKET_READ_TIMEOUT);
                         if (response == ResponseType.timeout)
                         {
                             mErrorString = "Packet truncated.";

--- a/RTProtocol.cs
+++ b/RTProtocol.cs
@@ -24,14 +24,6 @@ namespace QTMRealTimeSDK
         RateFrequencyDivisor
     }
 
-    public enum ReceiveResponseType
-    {
-        success,
-        timeout,
-        error,
-        disconnect
-    };
-
     /// <summary>Data with response from Discovery broadcast</summary>
     public struct DiscoveryResponse
     {
@@ -261,7 +253,7 @@ namespace QTMRealTimeSDK
                 }
 
                 //Get connection response from server
-                if (Receive(out packetType) == ReceiveResponseType.success)
+                if (Receive(out packetType) == ResponseType.success)
                 {
                     if (packetType == PacketType.PacketError)
                     {
@@ -388,14 +380,14 @@ namespace QTMRealTimeSDK
 
             switch (response)
             {
-                case ReceiveResponseType.success:
+                case ResponseType.success:
                     returnVal = RTPacket.GetPacketSize(data);
                     break;
-                case ReceiveResponseType.timeout:
+                case ResponseType.timeout:
                     returnVal = 0;
                     break;
-                case ReceiveResponseType.error:
-                case ReceiveResponseType.disconnect:
+                case ResponseType.error:
+                case ResponseType.disconnect:
                     returnVal = -1;
                     break;
             }
@@ -403,7 +395,7 @@ namespace QTMRealTimeSDK
             return returnVal;
         }
 
-        public ReceiveResponseType Receive(out PacketType packetType, bool skipEvents = true, int timeout = 5000000)
+        public ResponseType Receive(out PacketType packetType, bool skipEvents = true, int timeout = 5000000)
         {
             lock (receiveLock)
             {
@@ -417,24 +409,24 @@ namespace QTMRealTimeSDK
                     receivedTotal = 0;
 
                     var response = mNetwork.Receive(ref data, 0, data.Length, true, timeout);
-                    if (response == Response.ResponseType.timeout)
+                    if (response == ResponseType.timeout)
                     {
-                        return ReceiveResponseType.timeout; // Receive timeout
+                        return ResponseType.timeout; // Receive timeout
                     }
-                    if (response == Response.ResponseType.error)
+                    if (response == ResponseType.error)
                     {
                         mErrorString = "Socket Error.";
-                        return ReceiveResponseType.error;
+                        return ResponseType.error;
                     }
-                    if (response == Response.ResponseType.disconnect)
+                    if (response == ResponseType.disconnect)
                     {
                         mErrorString = "Disconnected from server.";
-                        return ReceiveResponseType.disconnect;
+                        return ResponseType.disconnect;
                     }
                     if (response.received < Constants.PACKET_HEADER_SIZE)
                     {
                         mErrorString = "QTM header not received.";
-                        return ReceiveResponseType.error;
+                        return ResponseType.error;
                     }
                     receivedTotal += response.received;
 
@@ -453,20 +445,20 @@ namespace QTMRealTimeSDK
                     {
                         // As long as we haven't received enough data, wait for more
                         response = mNetwork.Receive(ref data, receivedTotal, frameSize - receivedTotal, false, 5000000);
-                        if (response == Response.ResponseType.timeout)
+                        if (response == ResponseType.timeout)
                         {
                             mErrorString = "Packet truncated.";
-                            return ReceiveResponseType.error;
+                            return ResponseType.error;
                         }
-                        if (response == Response.ResponseType.error)
+                        if (response == ResponseType.error)
                         {
                             mErrorString = "Socket Error.";
-                            return ReceiveResponseType.error;
+                            return ResponseType.error;
                         }
-                        if (response == Response.ResponseType.disconnect)
+                        if (response == ResponseType.disconnect)
                         {
                             mErrorString = "Disconnected from server.";
-                            return ReceiveResponseType.disconnect;
+                            return ResponseType.disconnect;
                         }
                         receivedTotal += response.received;
                     }
@@ -476,11 +468,11 @@ namespace QTMRealTimeSDK
 
                 if (receivedTotal == frameSize)
                 {
-                    return ReceiveResponseType.success;
+                    return ResponseType.success;
                 }
                 mErrorString = "Packet truncated.";
 
-                return ReceiveResponseType.error;
+                return ResponseType.error;
             }
         }
 
@@ -700,12 +692,12 @@ namespace QTMRealTimeSDK
         {
             if (SendString("GetState", PacketType.PacketCommand))
             {
-                ReceiveResponseType response;
+                ResponseType response;
                 PacketType packetType;
                 do
                 {
                     response = Receive(out packetType, false, 2000000);
-                    if (response == ReceiveResponseType.success)
+                    if (response == ResponseType.success)
                     {
                         if (packetType == PacketType.PacketEvent)
                         {
@@ -714,7 +706,7 @@ namespace QTMRealTimeSDK
                         }
                     }
                 }
-                while (response == ReceiveResponseType.success);
+                while (response == ResponseType.success);
             }
             respondedEvent = QTMEvent.None;
             return false;
@@ -1255,7 +1247,7 @@ namespace QTMRealTimeSDK
             {
                 Thread.Sleep(50);
                 PacketType packetType;
-                while (Receive(out packetType, true) == ReceiveResponseType.success)
+                while (Receive(out packetType, true) == ResponseType.success)
                 {
                     if (packetType != PacketType.PacketXML)
                     {
@@ -1285,7 +1277,7 @@ namespace QTMRealTimeSDK
             if (SendString(command, PacketType.PacketCommand))
             {
                 PacketType packetType;
-                while (Receive(out packetType, true) == ReceiveResponseType.success)
+                while (Receive(out packetType, true) == ResponseType.success)
                 {
                     if (packetType == PacketType.PacketCommand)
                     {
@@ -1312,7 +1304,7 @@ namespace QTMRealTimeSDK
             if (SendString(xmlString, PacketType.PacketXML))
             {
                 PacketType packetType;
-                while (Receive(out packetType, true) == ReceiveResponseType.success)
+                while (Receive(out packetType, true) == ResponseType.success)
                 {
                     if (packetType == PacketType.PacketCommand)
                     {

--- a/SixDofViewer/SixDofViewer/MainWindow.cs
+++ b/SixDofViewer/SixDofViewer/MainWindow.cs
@@ -121,7 +121,7 @@ namespace SixDofViewer
 
             // Get RTPacket from stream
             PacketType packetType;
-            rtProtocol.ReceiveRTPacket(out packetType, false);
+            rtProtocol.Receive(out packetType, false);
 
             // Handle data packet
             if (packetType == PacketType.PacketData)


### PR DESCRIPTION
Changed RTNetwork.Receive to return a response class instead of an int. The struct contains an enum with: success, timeout, disconnect and error. And also number of received bytes. Previously there was no way of distinguishing between timeout and disconnect. RTNetwork.Receive uses [Socket.Receive](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.receive?view=net-5.0) and [Socket.ReceiveFrom](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.receivefrom?view=net-5.0), which both returns number of bytes read and 0 if the connection was shut down by the remote host.

Depricated RTProtocol.ReceiveRTPacket and replaced it with RTProtocol.Receive which returns an enum with respone type (success, timeout, error and disconnect).