### PR TITLE
Made sync out settings optional to pass xml validation in QTM

### DIFF
--- a/QTMSettings.cs
+++ b/QTMSettings.cs
@@ -647,13 +647,13 @@ namespace QTMRealTimeSDK.Settings
         public FieldOfView VideoFOV;
         /// <summary>Sync out settings for Oqus sync out or Sync Unit Out1</summary>
         [XmlElement("Sync_Out")]
-        public SettingsSyncOut SyncOut;
+        public SettingsSyncOut? SyncOut;
         /// <summary>Sync out settings for Sync Unit Out2</summary>
         [XmlElement("Sync_Out2")]
-        public SettingsSyncOut SyncOut2;
+        public SettingsSyncOut? SyncOut2;
         /// <summary>Sync out settings for Sync Unit Measurement Time (MT)</summary>
         [XmlElement("Sync_Out_MT")]
-        public SettingsSyncOut SyncOutMT;
+        public SettingsSyncOut? SyncOutMT;
         /// <summary>Lens Control settings for camera equipped with motorized lens</summary>
         [XmlElement("LensControl")]
         public SettingsLensControl LensControl;

--- a/RTClientSDK.Net.Example/ExampleSetGeneralSettings.cs
+++ b/RTClientSDK.Net.Example/ExampleSetGeneralSettings.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using QTMRealTimeSDK;
+using QTMRealTimeSDK.Settings;
+
+namespace RTClientSDK.Net.Example
+{
+    class ExampleSetGeneralSettings : Example
+    {
+        public ExampleSetGeneralSettings(RTProtocol rtProtocol, string ipAddress) : base(rtProtocol, ipAddress)
+        {         
+            if(!rtProtocol.Connect(ipAddress))
+            {
+                Console.WriteLine("Failed to connect: " + rtProtocol.GetErrorString());
+                return;
+            }
+
+            if(!rtProtocol.TakeControl("password"))
+            {
+                Console.WriteLine("Failed to take control: " + rtProtocol.GetErrorString());
+                return;
+            }
+
+            if(!rtProtocol.GetGeneralSettings())
+            {
+                Console.WriteLine("Failed to get general settings: " + rtProtocol.GetErrorString());
+                return;
+            }
+
+            if(!rtProtocol.SetGeneralSettings(rtProtocol.GeneralSettings))
+            {
+                Console.WriteLine("Failed to set general settings: " + rtProtocol.GetErrorString());
+                return;
+            }
+            
+           Console.WriteLine("Ok!");
+        }
+
+        public override void HandleStreaming()
+        {
+        }
+    }
+}

--- a/RTClientSDK.Net.Example/Program.cs
+++ b/RTClientSDK.Net.Example/Program.cs
@@ -18,12 +18,14 @@ namespace RTClientSDK.Net.Example
             //Example example = new ExampleSkeleton(mRtProtocol, mIpAddress);
             //Example example = new Example3D(mRtProtocol, mIpAddress);
             //Example example = new ExampleImage(mRtProtocol, mIpAddress);
-            Example example = new Example2D(mRtProtocol, mIpAddress);
+            //Example example = new Example2D(mRtProtocol, mIpAddress);
             //Example example = new Example6D(mRtProtocol, mIpAddress);
             //Example example = new ExampleGaze(mRtProtocol, mIpAddress);
             //Example example = new ExampleEyeTracker(mRtProtocol, mIpAddress);
             //Example example = new ExampleTimecode(mRtProtocol, mIpAddress);
             //Example example = new ExampleUDP(mRtProtocol, mIpAddress);
+            //Example example = new ExampleUDP(mRtProtocol, mIpAddress);
+            Example example = new ExampleSetGeneralSettings(mRtProtocol, mIpAddress);
             MainExample mainExample = new MainExample(example, mRtProtocol, mIpAddress);
             mainExample.DiscoverQTMServers(4545);
             Console.WriteLine("Press key to continue");

--- a/RTClientSDK.Net.Example/RTClientSDK.Net.Example.csproj
+++ b/RTClientSDK.Net.Example/RTClientSDK.Net.Example.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ExampleEyeTracker.cs" />
     <Compile Include="ExampleGaze.cs" />
     <Compile Include="ExampleImage.cs" />
+    <Compile Include="ExampleSetGeneralSettings.cs" />
     <Compile Include="ExampleSkeleton.cs" />
     <Compile Include="ExampleTimecode.cs" />
     <Compile Include="ExampleUDP.cs" />


### PR DESCRIPTION

## Problem
Setting general settings fails (returns false) for most cameras. The sync out values are validated in QTM if they exist in the provided XML.
The RTClientSDK.NET provides default values for all possible sync out fields even if they are not used.

## Solution
This pull request makes the sync out settings default to null, which makes the settings XML pass validation.
