### PR TITLE
Handle file closed

### DIFF
--- a/RTProtocol.cs
+++ b/RTProtocol.cs
@@ -810,7 +810,8 @@ namespace QTMRealTimeSDK
             {
                 if (response == "Closing connection" ||
                     response == "No connection to close" ||
-                    response == "Closing file")
+                    response == "Closing file" ||
+                    response == "File closed")
                 {
                     return true;
                 }


### PR DESCRIPTION
## Problem 
When QTM closes a measurement file it responds via RT by sending the string "File closed". This isn't handled by the RTClientSDK.NET 

## Solution
This pull requests modifies ``CRTProtocol::CloseMeasurement()`` to handle the "File closed" response when sending the "Close" command.