### PR TITLE
Remove deprecated settings types

### DIFF
--- a/QTMSettings.cs
+++ b/QTMSettings.cs
@@ -164,8 +164,6 @@ namespace QTMRealTimeSDK.Settings
     [XmlRoot("The_6D")]
     public class Settings6D : SettingsBase
     {
-        [XmlElement("Bodies")]
-        public int BodyCount;
         [XmlElement("Body")]
         public List<Settings6DOF> Bodies;
     }

--- a/QTMSettings.cs
+++ b/QTMSettings.cs
@@ -162,79 +162,12 @@ namespace QTMRealTimeSDK.Settings
 
     /// <summary>6D Settings from QTM</summary>
     [XmlRoot("The_6D")]
-    public class Settings6D_V1 : SettingsBase
+    public class Settings6D : SettingsBase
     {
-        internal static Settings6D ConvertToSettings6DOF(Settings6D_V1 settings)
-        {
-            return new Settings6D(settings.Xml, settings.BodyCount, settings.Bodies.ConvertAll<Settings6DOF>(Settings6DOF_V1.ConvertToSettings6DOF), settings.EulerNames);
-        }
-
         [XmlElement("Bodies")]
         public int BodyCount;
         [XmlElement("Body")]
-        public List<Settings6DOF_V1> Bodies;
-        [XmlElement("Euler")]
-        public EulerNames EulerNames;
-    }
-
-    [XmlRoot("Euler")]
-    public class EulerNames
-    {
-        public EulerNames()
-        {
-            First = "Roll";
-            Second = "Pitch";
-            Third = "Yaw";
-        }
-
-        [XmlElement("First")]
-        public string First;
-        [XmlElement("Second")]
-        public string Second;
-        [XmlElement("Third")]
-        public string Third;
-    }
-
-    /// <summary>6D Settings from QTM</summary>
-    [XmlRoot("The_6D")]
-    public class Settings6D_V2 : SettingsBase
-    {
-        public Settings6D_V2() { }
-        internal Settings6D_V2(Settings6D settings)
-        {
-            Bodies = settings.Bodies.ConvertAll<Settings6DOF_V2>(Settings6DOF.ConvertToSettings6DOF_V2);
-        }
-
-        internal static Settings6D ConvertToSettings6DOF(Settings6D_V2 settings)
-        {
-            return new Settings6D(settings.Xml, settings.Bodies.Count, settings.Bodies.ConvertAll<Settings6DOF>(Settings6DOF_V2.ConvertToSettings6DOF), new EulerNames());
-        }
-        [XmlElement("Body")]
-        public List<Settings6DOF_V2> Bodies;
-    }
-
-    public class Settings6D : SettingsBase
-    {
-        public Settings6D()
-        {
-#pragma warning disable CS0618 // Type or member is obsolete 
-            EulerNames = new EulerNames();
-#pragma warning restore CS0618 // Type or member is obsolete 
-        }
-        public Settings6D(string xml, int bodyCount, List<Settings6DOF> bodies, EulerNames eulerNames)
-        {
-            Xml = xml;
-            BodyCount = bodyCount;
-            Bodies = bodies;
-#pragma warning disable CS0618 // Type or member is obsolete 
-            EulerNames = eulerNames;
-#pragma warning restore CS0618 // Type or member is obsolete 
-        }
-
-        public int BodyCount;
         public List<Settings6DOF> Bodies;
-        [Obsolete("EulerNames is moved to general settings from protocol version 1.21.", false)]
-        public EulerNames EulerNames;
     }
 
     /// <summary>Analog Settings from QTM</summary>
@@ -1016,48 +949,10 @@ namespace QTMRealTimeSDK.Settings
         public int Frequency;
     }
 
-    /// <summary>Struct for 6dof point information</summary>
-    public struct Settings6DOFPoint_V1
-    {
-        internal static Settings6DOFPoint ConvertToSettingsPoint(Settings6DOFPoint_V1 settingsPoint)
-        {
-            return new Settings6DOFPoint("", settingsPoint.X, settingsPoint.Y, settingsPoint.Z, settingsPoint.Virtual, settingsPoint.PhysicalId);
-        }
-        [XmlElement("X")]
-        public float X;
-        [XmlElement("Y")]
-        public float Y;
-        [XmlElement("Z")]
-        public float Z;
-        [XmlElement("PhysicalId")]
-        public int PhysicalId;
-        [XmlElement("Virtual")]
-        public bool Virtual;
-    }
-
-    /// <summary>Settings for 6DOF bodies</summary>
-    public struct Settings6DOF_V1
-    {
-        internal static Settings6DOF ConvertToSettings6DOF(Settings6DOF_V1 settings6DOF)
-        {
-            return new Settings6DOF(settings6DOF.Name, true, settings6DOF.ColorRGB, 0, 0, 0, new Settings6DOFFilter(), new Settings6DOFMesh(),
-                settings6DOF.Points.ConvertAll<Settings6DOFPoint>(Settings6DOFPoint_V1.ConvertToSettingsPoint), new Settings6DOFDataOrigin(), new Settings6DOFDataOrientation());
-        }
-        /// <summary>Name of 6DOF body</summary>
-        [XmlElement("Name")]
-        public string Name;
-        /// <summary>Color of 6DOF body</summary>
-        [XmlElement("RGBColor")]
-        public int ColorRGB;
-        /// <summary>List of points in 6DOF body</summary>
-        [XmlElement("Point")]
-        public List<Settings6DOFPoint_V1> Points;
-    }
-
     /// <summary>Struct for 6dof filter</summary>
-    public struct Settings6DOFColor_V2
+    public struct Settings6DOFColor
     {
-        internal Settings6DOFColor_V2(int ColorRGB)
+        internal Settings6DOFColor(int ColorRGB)
         {
             R = (ColorRGB & 0xff);
             G = ((ColorRGB >> 8) & 0xff);
@@ -1155,28 +1050,8 @@ namespace QTMRealTimeSDK.Settings
         public float R33;
     }
 
-    public struct Settings6DOF_V2
+    public struct Settings6DOF
     {
-        internal Settings6DOF_V2(Settings6DOF settings)
-        {
-            Name = settings.Name;
-            Enabled = settings.Enabled;
-            Color = new Settings6DOFColor_V2(settings.ColorRGB);
-            MaximumResidual = settings.MaximumResidual;
-            MinimumMarkersInBody = settings.MinimumMarkersInBody;
-            BoneLengthTolerance = settings.BoneLengthTolerance;
-            Filter = settings.Filter;
-            Mesh = settings.Mesh;
-            Points = settings.Points;
-            DataOrigin = settings.DataOrigin;
-            DataOrientation = settings.DataOrientation;
-        }
-        internal static Settings6DOF ConvertToSettings6DOF(Settings6DOF_V2 settings6DOF)
-        {
-            int colorRGB = (settings6DOF.Color.R & 0xff) | ((settings6DOF.Color.G << 8) & 0xff00) | ((settings6DOF.Color.B << 16) & 0xff0000);
-            return new Settings6DOF(settings6DOF.Name, settings6DOF.Enabled, colorRGB, settings6DOF.MaximumResidual, settings6DOF.MinimumMarkersInBody, settings6DOF.BoneLengthTolerance,
-                settings6DOF.Filter, settings6DOF.Mesh, settings6DOF.Points, settings6DOF.DataOrigin, settings6DOF.DataOrientation);
-        }
         /// <summary>Name of 6DOF body</summary>
         [XmlElement("Name")]
         public string Name;
@@ -1185,7 +1060,7 @@ namespace QTMRealTimeSDK.Settings
         public bool Enabled;
         /// <summary>Color of 6DOF body</summary>
         [XmlElement("Color")]
-        public Settings6DOFColor_V2 Color;
+        public Settings6DOFColor Color;
         /// <summary>Maximum residual of 6DOF body</summary>
         [XmlElement("MaximumResidual")]
         public float MaximumResidual;
@@ -1236,51 +1111,6 @@ namespace QTMRealTimeSDK.Settings
         public bool Virtual;
         [XmlAttribute("PhysicalId")]
         public int PhysicalId;
-    }
-
-    public struct Settings6DOF
-    {
-        internal static Settings6DOF_V2 ConvertToSettings6DOF_V2(Settings6DOF settings)
-        {
-            return new Settings6DOF_V2(settings);
-        }
-        public Settings6DOF(string name, bool enabled, int colorRGB, float maxResidual, int minimumMarkersInBody, float boneLengthTolerance, Settings6DOFFilter filter, Settings6DOFMesh mesh,
-            List<Settings6DOFPoint> points, Settings6DOFDataOrigin dataOrigin, Settings6DOFDataOrientation dataOrientation)
-        {
-            Name = name;
-            Enabled = enabled;
-            ColorRGB = colorRGB;
-            MaximumResidual = maxResidual;
-            MinimumMarkersInBody = minimumMarkersInBody;
-            BoneLengthTolerance = boneLengthTolerance;
-            Filter = filter;
-            Mesh = mesh;
-            Points = points;
-            DataOrigin = dataOrigin;
-            DataOrientation = dataOrientation;
-        }
-        /// <summary>Name of 6DOF body</summary>
-        public string Name;
-        /// <summary>Availability of 6DOF body</summary>
-        public bool Enabled;
-        /// <summary>Color of 6DOF body</summary>
-        public int ColorRGB;
-        /// <summary>Maximum residual of 6DOF body</summary>
-        public float MaximumResidual;
-        /// <summary>Minimum markers in 6DOF body</summary>
-        public int MinimumMarkersInBody;
-        /// <summary>Bone length tolerance of 6DOF body</summary>
-        public float BoneLengthTolerance;
-        /// <summary>Filter of 6DOF body</summary>
-        public Settings6DOFFilter Filter;
-        /// <summary>Mesh of 6DOF body</summary>
-        public Settings6DOFMesh Mesh;
-        /// <summary>List of points in 6DOF body</summary>
-        public List<Settings6DOFPoint> Points;
-        /// <summary>Data origin of 6DOF body</summary>
-        public Settings6DOFDataOrigin DataOrigin;
-        /// <summary>Data orientation of 6DOF body</summary>
-        public Settings6DOFDataOrientation DataOrientation;
     }
 
     /// <summary>General settings for Analog devices</summary>

--- a/RTProtocol.cs
+++ b/RTProtocol.cs
@@ -929,38 +929,7 @@ namespace QTMRealTimeSDK
         /// <returns>Returns true if settings was retrieved</returns>
         public bool Get6dSettings()
         {
-            if (mMajorVersion > 1 || mMinorVersion > 20)
-            {
-                Settings6D_V2 settings6D_v2;
-                if (GetSettings("6D", "The_6D", out settings6D_v2))
-                {
-                    m6DOFSettings = Settings6D_V2.ConvertToSettings6DOF(settings6D_v2);
-                    return true;
-                }
-            }
-            else
-            {
-                Settings6D_V1 settings6D_v1;
-                if (GetSettings("6D", "The_6D", out settings6D_v1))
-                {
-                    m6DOFSettings = Settings6D_V1.ConvertToSettings6DOF(settings6D_v1);
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        /// <summary>Get 6DOF settings from XML string</summary>
-        /// <returns>Returns true if settings was retrieved</returns>
-        public static bool Get6dSettings(string xmlData, out Settings6D settings, out string error)
-        {
-            xmlData = xmlData.Replace("QTM_Body_File_Ver_1.00", "The_6D");
-            settings = Settings6D_V2.ConvertToSettings6DOF(RTProtocol.ReadSettings<Settings6D_V2>("The_6D", xmlData, out error));
-            if (settings != null)
-            {
-                return true;
-            }
-            return false;
+            return GetSettings("6D", "The_6D", out m6DOFSettings);
         }
 
         /// <summary>Get Analog settings from QTM Server</summary>
@@ -1134,28 +1103,7 @@ namespace QTMRealTimeSDK
 
         public bool Set6DSettings(Settings6D settings)
         {
-            if (mMajorVersion > 1 || mMinorVersion > 20)
-            {
-                Settings6D_V2 settings6D_v2 = new Settings6D_V2(settings);
-                return SetSettings("6D", "The_6D", settings6D_v2);
-            }
-            mErrorString = "Can not set 6D settings in protocol versions prior to 1.21";
-            return false;
-        }
-
-        public static bool Set6DSettings(Settings6D settings, out string xmlData, out string error)
-        {
-            Settings6D_V2 settings6D_v2 = new Settings6D_V2(settings);
-
-            xmlData = RTProtocol.CreateSettingsXml(settings6D_v2, out error);
-            if (xmlData != string.Empty)
-            {
-                xmlData = xmlData.Replace("</QTM_Settings>", "");
-                xmlData = xmlData.Replace("<QTM_Settings>", "");
-                xmlData = xmlData.Replace("The_6D", "QTM_Body_File_Ver_1.00");
-                return true;
-            }
-            return false;
+            return SetSettings("6D", "The_6D", settings);
         }
 
         public bool SetForceSettings(SettingsForce settings)

--- a/SixDofViewer/SixDofViewer/MainWindow.cs
+++ b/SixDofViewer/SixDofViewer/MainWindow.cs
@@ -94,7 +94,7 @@ namespace SixDofViewer
 
                 if (sixDofBodyNameToUse.Length > 0)
                 {
-                    for (int bodyIndex = 0; bodyIndex < rtProtocol.Settings6DOF.BodyCount; bodyIndex++)
+                    for (int bodyIndex = 0; bodyIndex < rtProtocol.Settings6DOF.Bodies.Count; bodyIndex++)
                     {
                         if (string.Equals(rtProtocol.Settings6DOF.Bodies[bodyIndex].Name, sixDofBodyNameToUse, StringComparison.OrdinalIgnoreCase))
                         {
@@ -105,7 +105,7 @@ namespace SixDofViewer
                 }
                 else
                 {
-                    if (rtProtocol.Settings6DOF.BodyCount > 0)
+                    if (rtProtocol.Settings6DOF.Bodies.Count > 0)
                     {
                         sixDofBodyNameToUse = rtProtocol.Settings6DOF.Bodies[0].Name;
                         bodyIndexToUse = 0;


### PR DESCRIPTION
* Remove compatibility with RTSDK versions `<= 1.20`.
* All 6DoF settings are now unified to a single type, as other settings are. 
* Altered example project to use modern 6DoF body count. 